### PR TITLE
Fix #7

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,0 @@
-https://josephting.netlify.com/* https://josephting.my/:splat 301!

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,9 @@
     for = "/css/coder*.css"
     [headers.values]
         Access-Control-Allow-Origin = "*"
+
+[[redirects]]
+    from = "https://josephting.netlify.com/*"
+    to = "https://josephting.my/:splat"
+    status = 301
+    force = true


### PR DESCRIPTION
Use `netlify.toml` to define redirects instead of using `_redirects` file.

NOTE: `_redirects` file should have been in the public directory.