### PR TITLE
Add 404 redirect to archive year/month

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,3 +8,15 @@
     to = "https://josephting.my/:splat"
     status = 301
     force = true
+
+[[redirects]]
+    from = "/archive-year/"
+    to = "/404.html"
+    status = 404
+    force = true
+
+[[redirects]]
+    from = "/archive-month/"
+    to = "/404.html"
+    status = 404
+    force = true


### PR DESCRIPTION
`/archive-year/` & `/archive-month/` currently displaying 404 page with 200 status code.

This PR is to change the status code to 404.