### PR TITLE
Switch to GA4 measurement ID

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@ baseURL = "https://josephting.my"
 languageCode = "en-us"
 title = "Joseph Ting"
 theme = "hugo-coder"
-googleAnalytics = "UA-5454059-25"
+googleAnalytics = "G-R5WW6VSNKF"
 pygmentsCodeFences = true
 
 [params]


### PR DESCRIPTION
Universal Analytics is deprecated.

Moving to GA4.